### PR TITLE
Version 3.2.2 — Core Data caching for notifications and messages

### DIFF
--- a/Nightflyy.xcodeproj/project.pbxproj
+++ b/Nightflyy.xcodeproj/project.pbxproj
@@ -366,7 +366,7 @@
 				CODE_SIGN_ENTITLEMENTS = Nightflyy/Nightflyy.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_ASSET_PATHS = "\"Nightflyy/Preview Content\"";
 				DEVELOPMENT_TEAM = YVH7KZM656;
 				ENABLE_PREVIEWS = YES;
@@ -389,7 +389,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.2.1;
+				MARKETING_VERSION = 3.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.com.slydelife.Slyde;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -413,7 +413,7 @@
 				CODE_SIGN_ENTITLEMENTS = Nightflyy/Nightflyy.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_ASSET_PATHS = "\"Nightflyy/Preview Content\"";
 				DEVELOPMENT_TEAM = YVH7KZM656;
 				ENABLE_PREVIEWS = YES;
@@ -437,7 +437,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.2.1;
+				MARKETING_VERSION = 3.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.slydelife.Slyde;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Nightflyy.xcodeproj/project.pbxproj
+++ b/Nightflyy.xcodeproj/project.pbxproj
@@ -372,6 +372,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Nightflyy/Info.plist;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.entertainment";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "This app uses your location to display nearby events.";
 				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "This app uses your location to display nearby events.";
@@ -419,6 +420,7 @@
 				GCC_OPTIMIZATION_LEVEL = s;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Nightflyy/Info.plist;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.entertainment";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "This app uses your location to display nearby events.";
 				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "This app uses your location to display nearby events.";

--- a/Nightflyy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Nightflyy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ab180/airbridge-ios-sdk-deployment",
       "state" : {
-        "revision" : "d1fffd94d7bc22f46d0127faea2a7974f21bde17",
-        "version" : "4.9.1"
+        "revision" : "5c4fb28e913fcc52f694cd9ca555bf6c298da33b",
+        "version" : "4.9.3"
       }
     },
     {
@@ -133,7 +133,7 @@
       "location" : "https://github.com/mixpanel/mixpanel-swift",
       "state" : {
         "branch" : "master",
-        "revision" : "b4cb3f6e3e3084e1637c4dfe06c2dcda169ff523"
+        "revision" : "6e2a786b1e88b57b90f5a6d401337bc1bb2ba69c"
       }
     },
     {
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/qonversion/qonversion-ios-sdk",
       "state" : {
-        "revision" : "f610ca5d8d27c8010725d26e8d18283ae210be9d",
-        "version" : "6.0.0"
+        "revision" : "aec38505b6441cdd2453da9d74a881f3eeab2c09",
+        "version" : "6.9.0"
       }
     },
     {
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
-        "version" : "1.10.1"
+        "revision" : "8c0f217f01000dd30f60d6e536569ad4e74291f9",
+        "version" : "1.11.0"
       }
     },
     {

--- a/Nightflyy/Enums/UserDefaultsKeys.swift
+++ b/Nightflyy/Enums/UserDefaultsKeys.swift
@@ -11,16 +11,19 @@ enum UserDefaultsKeys :String {
     case hideSwipeForActionsPrompt
     case bonusCredit
     case nfpReferred
-    
+    case lastNotificationsFetchDate
+
     func getValue<T>() -> T? {
         switch self {
-            
+
         case .hideSwipeForActionsPrompt:
-            UserDefaults.standard.bool(forKey: rawValue) as? T 
+            UserDefaults.standard.bool(forKey: rawValue) as? T
         case .bonusCredit:
             UserDefaults.standard.integer(forKey: rawValue) as? T
         case .nfpReferred:
             UserDefaults.standard.string(forKey: rawValue) as? T
+        case .lastNotificationsFetchDate:
+            UserDefaults.standard.object(forKey: rawValue) as? Date as? T
         }
    
     }

--- a/Nightflyy/Info.plist
+++ b/Nightflyy/Info.plist
@@ -2,10 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AIRBRIDGE_TOKEN</key>
+	<string>$(AIRBRIDGE_TOKEN)</string>
 	<key>ALGOLIA_SEARCH_KEY</key>
 	<string>$(ALGOLIA_SEARCH_KEY)</string>
 	<key>APPID</key>
 	<string>$(APPID)</string>
+	<key>APPNAME</key>
+	<string>$(APPNAME)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -35,10 +39,6 @@
 	<string>$(SENDGRID_BASEURL)</string>
 	<key>SENDGRID_KEY</key>
 	<string>$(SENDGRID_KEY)</string>
-	<key>APPNAME</key>
-	<string>$(APPNAME)</string>
-	<key>AIRBRIDGE_TOKEN</key>
-	<string>$(AIRBRIDGE_TOKEN)</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Bebas-Regular.ttf</string>

--- a/Nightflyy/Managers/AppNotificationsManager.swift
+++ b/Nightflyy/Managers/AppNotificationsManager.swift
@@ -6,37 +6,50 @@
 //
 
 import SwiftUI
+import CoreData
 import OSLog
 
 @Observable @MainActor
 class AppNotificationsManager {
-    
+
     static let shared = AppNotificationsManager()
-    
+
     var notifications: [AppNotification] = .init()
-    
+
     private let notificationClient: any AppNotificationClientProtocol
-    
-    private init(notificationClient: any AppNotificationClientProtocol = AppNotificationClient.shared) {
+    private let viewContext: NSManagedObjectContext
+
+    private init(
+        notificationClient: any AppNotificationClientProtocol = AppNotificationClient.shared,
+        viewContext: NSManagedObjectContext = PersistenceController.shared.container.viewContext
+    ) {
         self.notificationClient = notificationClient
+        self.viewContext = viewContext
     }
-    
+
     func fetchNotifications(refetch: Bool = false) async {
+        // Load cached notifications from Core Data for instant display
+        notifications = loadFromCache()
+
         if notifications.isEmpty || refetch {
             do {
-                notifications = try await notificationClient.fetchNewAppNotifications(lastUpdated: nil)
-                notifications.sort { $0.date > $1.date }
+                let lastFetchDate: Date? = UserDefaultsKeys.lastNotificationsFetchDate.getValue()
+                let newNotifications = try await notificationClient.fetchNewAppNotifications(lastUpdated: lastFetchDate)
+                saveToCache(newNotifications)
+                UserDefaultsKeys.lastNotificationsFetchDate.setValue(Date.now)
+                notifications = loadFromCache()
             }
             catch {
                 Logger.general.error("Error fetching notifications: \(error.localizedDescription)")
             }
         }
     }
-    
+
     func deleteNotification(withId notificationId: String) {
         Task {
             do {
                 try await notificationClient.deleteNotification(notificationId)
+                deleteFromCache(notificationId)
                 notifications.removeAll { $0.id == notificationId }
             }
             catch {
@@ -44,7 +57,59 @@ class AppNotificationsManager {
             }
         }
     }
-    
-    
-    
+
+    // MARK: - Core Data Helpers
+
+    private func loadFromCache() -> [AppNotification] {
+        let request = NSFetchRequest<CachedAppNotification>(entityName: "CachedAppNotification")
+        request.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
+        do {
+            let cached = try viewContext.fetch(request)
+            return cached.compactMap { AppNotification.from($0) }
+        }
+        catch {
+            Logger.general.error("Error loading notifications from cache: \(error.localizedDescription)")
+            return []
+        }
+    }
+
+    private func saveToCache(_ notifications: [AppNotification]) {
+        for notification in notifications {
+            let request = NSFetchRequest<CachedAppNotification>(entityName: "CachedAppNotification")
+            request.predicate = NSPredicate(format: "id == %@", notification.id ?? "")
+            request.fetchLimit = 1
+
+            do {
+                let existing = try viewContext.fetch(request).first
+                let entity = existing ?? CachedAppNotification(context: viewContext)
+                notification.populate(entity)
+            }
+            catch {
+                Logger.general.error("Error upserting notification to cache: \(error.localizedDescription)")
+            }
+        }
+
+        do {
+            try viewContext.save()
+        }
+        catch {
+            Logger.general.error("Error saving notification cache: \(error.localizedDescription)")
+        }
+    }
+
+    private func deleteFromCache(_ notificationId: String) {
+        let request = NSFetchRequest<CachedAppNotification>(entityName: "CachedAppNotification")
+        request.predicate = NSPredicate(format: "id == %@", notificationId)
+        request.fetchLimit = 1
+
+        do {
+            if let cached = try viewContext.fetch(request).first {
+                viewContext.delete(cached)
+                try viewContext.save()
+            }
+        }
+        catch {
+            Logger.general.error("Error deleting notification from cache: \(error.localizedDescription)")
+        }
+    }
 }

--- a/Nightflyy/Managers/ChatsManager.swift
+++ b/Nightflyy/Managers/ChatsManager.swift
@@ -81,22 +81,33 @@ class ChatsManager {
         }
     }
     
-    func createMessagesListener(uid: String, completion: @escaping ([Message]) -> Void) {
-        var messages = [Message]()
+    func createMessagesListener(uid: String, sinceDate: Date?, completion: @escaping ([Message]) -> Void) {
         messagesListener?.remove()
         let db = FirebaseManager.shared.db
-        let query = db.collection(FirestoreCollections.Chats.value).document(uid).collection(FirestoreCollections.Messages.value)
-//            .whereField("date", isGreaterThan: Date().addingTimeInterval(-3600))
-            .order(by: FirestoreCollections.Messages.date, descending: false)
+        let collection = db.collection(FirestoreCollections.Chats.value).document(uid).collection(FirestoreCollections.Messages.value)
+        var query: Query = collection.order(by: FirestoreCollections.Messages.date, descending: false)
+        if let sinceDate {
+            query = collection
+                .whereField(FirestoreCollections.Messages.date, isGreaterThan: sinceDate)
+                .order(by: FirestoreCollections.Messages.date, descending: false)
+        }
         messagesListener = query.addSnapshotListener { snapshot, error in
+            var newMessages = [Message]()
             snapshot?.documentChanges.forEach { change in
                 if change.type == .added {
                     guard let message = try? change.document.data(as: Message.self) else { return }
-                    messages.append(message)
+                    newMessages.append(message)
                 }
             }
-            completion(messages)
+            if !newMessages.isEmpty {
+                completion(newMessages)
+            }
         }
+    }
+
+    func stopMessagesListener() {
+        messagesListener?.remove()
+        messagesListener = nil
     }
     
     func getChat(with accountId: String) throws -> Chat {

--- a/Nightflyy/Models/AppNotification+CoreData.swift
+++ b/Nightflyy/Models/AppNotification+CoreData.swift
@@ -1,0 +1,61 @@
+//
+//  AppNotification+CoreData.swift
+//  Nightflyy
+//
+//  Created by Bernie Cartin on 4/3/26.
+//
+
+import CoreData
+
+extension AppNotification {
+
+    /// Creates an `AppNotification` from a `CachedAppNotification` Core Data entity.
+    static func from(_ cached: CachedAppNotification) -> AppNotification? {
+        guard let id = cached.id,
+              let sender = cached.sender,
+              let date = cached.date,
+              let typeRaw = cached.notificationType,
+              let type = AppNotificationType(rawValue: typeRaw) else {
+            return nil
+        }
+        var notification = AppNotification(
+            sender: sender,
+            date: date,
+            type: type,
+            notificationData: NotificationData(
+                event_flyer_url: cached.eventFlyerUrl,
+                event_id: cached.eventId,
+                event_name: cached.eventName,
+                event_status: cached.eventStatus,
+                start_reminder: cached.startReminder,
+                created_by: cached.createdBy,
+                profile_image_url: cached.profileImageUrl,
+                username: cached.username,
+                rating: cached.rating,
+                topic_id: cached.topicId,
+                topic_name: cached.topicName
+            )
+        )
+        notification.id = id
+        return notification
+    }
+
+    /// Populates a `CachedAppNotification` entity with values from this struct.
+    func populate(_ cached: CachedAppNotification) {
+        cached.id = id
+        cached.sender = sender
+        cached.date = date
+        cached.notificationType = type.rawValue
+        cached.eventFlyerUrl = notificationData.event_flyer_url
+        cached.eventId = notificationData.event_id
+        cached.eventName = notificationData.event_name
+        cached.eventStatus = notificationData.event_status
+        cached.startReminder = notificationData.start_reminder
+        cached.createdBy = notificationData.created_by
+        cached.profileImageUrl = notificationData.profile_image_url
+        cached.username = notificationData.username
+        cached.rating = notificationData.rating
+        cached.topicId = notificationData.topic_id
+        cached.topicName = notificationData.topic_name
+    }
+}

--- a/Nightflyy/Models/Message+CoreData.swift
+++ b/Nightflyy/Models/Message+CoreData.swift
@@ -1,0 +1,56 @@
+//
+//  Message+CoreData.swift
+//  Nightflyy
+//
+//  Created by Bernie Cartin on 4/3/26.
+//
+
+import CoreData
+
+extension Message {
+
+    /// Creates a `Message` from a `CachedMessage` Core Data entity.
+    static func from(_ cached: CachedMessage) -> Message? {
+        guard let id = cached.id,
+              let sender = cached.sender,
+              let recipient = cached.recipient,
+              let typeRaw = cached.messageType,
+              let type = MessageType(rawValue: typeRaw) else {
+            return nil
+        }
+        var message = Message(
+            sender: sender,
+            recipient: recipient,
+            date: cached.date,
+            type: type,
+            messageData: MessageData(
+                message: cached.message,
+                event_name: cached.eventName,
+                event_id: cached.eventId,
+                event_flyer_url: cached.eventFlyerUrl,
+                username: cached.username,
+                uid: cached.uid,
+                profile_image_url: cached.profileImageUrl
+            )
+        )
+        message.id = id
+        return message
+    }
+
+    /// Populates a `CachedMessage` entity with values from this struct.
+    /// Note: `chatId` must be set separately by the caller.
+    func populate(_ cached: CachedMessage) {
+        cached.id = id
+        cached.sender = sender
+        cached.recipient = recipient
+        cached.date = date
+        cached.messageType = type.rawValue
+        cached.message = messageData.message
+        cached.eventName = messageData.event_name
+        cached.eventId = messageData.event_id
+        cached.eventFlyerUrl = messageData.event_flyer_url
+        cached.username = messageData.username
+        cached.uid = messageData.uid
+        cached.profileImageUrl = messageData.profile_image_url
+    }
+}

--- a/Nightflyy/Network/AppNotificationClient.swift
+++ b/Nightflyy/Network/AppNotificationClient.swift
@@ -18,8 +18,10 @@ class AppNotificationClient {
             return []
         }
         var notifications: [AppNotification] = .init()
-        let dbRef = FirebaseManager.shared.db.collection(FirestoreCollections.Accounts.value).document(uid).collection(FirestoreCollections.Accounts.notifications)
-//            .whereField("date", isGreaterThan: lastUpdated ?? Date(timeIntervalSince1970: 0))
+        var dbRef: Query = FirebaseManager.shared.db.collection(FirestoreCollections.Accounts.value).document(uid).collection(FirestoreCollections.Accounts.notifications)
+        if let lastUpdated {
+            dbRef = dbRef.whereField("date", isGreaterThan: lastUpdated)
+        }
         let snapshot = try await dbRef.getDocuments()
         notifications = try snapshot.documents.map({ document in
             return try document.data(as: AppNotification.self)

--- a/Nightflyy/Nightflyy.xcdatamodeld/Nightflyy.xcdatamodel/contents
+++ b/Nightflyy/Nightflyy.xcdatamodeld/Nightflyy.xcdatamodel/contents
@@ -17,11 +17,27 @@
         <attribute name="topicName" optional="YES" attributeType="String"/>
         <attribute name="username" optional="YES" attributeType="String"/>
     </entity>
+    <entity name="CachedMessage" representedClassName="CachedMessage" syncable="YES" codeGenerationType="class">
+        <attribute name="chatId" attributeType="String"/>
+        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="eventFlyerUrl" optional="YES" attributeType="String"/>
+        <attribute name="eventId" optional="YES" attributeType="String"/>
+        <attribute name="eventName" optional="YES" attributeType="String"/>
+        <attribute name="id" attributeType="String"/>
+        <attribute name="message" optional="YES" attributeType="String"/>
+        <attribute name="messageType" attributeType="String"/>
+        <attribute name="profileImageUrl" optional="YES" attributeType="String"/>
+        <attribute name="recipient" attributeType="String"/>
+        <attribute name="sender" attributeType="String"/>
+        <attribute name="uid" optional="YES" attributeType="String"/>
+        <attribute name="username" optional="YES" attributeType="String"/>
+    </entity>
     <entity name="Item" representedClassName="Item" syncable="YES" codeGenerationType="class">
         <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
     </entity>
     <elements>
         <element name="CachedAppNotification" positionX="160" positionY="0" width="128" height="254"/>
+        <element name="CachedMessage" positionX="320" positionY="0" width="128" height="224"/>
         <element name="Item" positionX="-63" positionY="-18" width="128" height="44"/>
     </elements>
 </model>

--- a/Nightflyy/Nightflyy.xcdatamodeld/Nightflyy.xcdatamodel/contents
+++ b/Nightflyy/Nightflyy.xcdatamodeld/Nightflyy.xcdatamodel/contents
@@ -1,9 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="false" userDefinedModelVersionIdentifier="">
+    <entity name="CachedAppNotification" representedClassName="CachedAppNotification" syncable="YES" codeGenerationType="class">
+        <attribute name="createdBy" optional="YES" attributeType="String"/>
+        <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="eventFlyerUrl" optional="YES" attributeType="String"/>
+        <attribute name="eventId" optional="YES" attributeType="String"/>
+        <attribute name="eventName" optional="YES" attributeType="String"/>
+        <attribute name="eventStatus" optional="YES" attributeType="String"/>
+        <attribute name="id" attributeType="String"/>
+        <attribute name="notificationType" attributeType="String"/>
+        <attribute name="profileImageUrl" optional="YES" attributeType="String"/>
+        <attribute name="rating" optional="YES" attributeType="String"/>
+        <attribute name="sender" attributeType="String"/>
+        <attribute name="startReminder" optional="YES" attributeType="String"/>
+        <attribute name="topicId" optional="YES" attributeType="String"/>
+        <attribute name="topicName" optional="YES" attributeType="String"/>
+        <attribute name="username" optional="YES" attributeType="String"/>
+    </entity>
     <entity name="Item" representedClassName="Item" syncable="YES" codeGenerationType="class">
         <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
     </entity>
     <elements>
+        <element name="CachedAppNotification" positionX="160" positionY="0" width="128" height="254"/>
         <element name="Item" positionX="-63" positionY="-18" width="128" height="44"/>
     </elements>
 </model>

--- a/Nightflyy/Screens/Inbox/ViewModels/InboxRowViewModel.swift
+++ b/Nightflyy/Screens/Inbox/ViewModels/InboxRowViewModel.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 import SwiftUI
+import CoreData
+import OSLog
 
 @Observable @MainActor
 class InboxRowViewModel: Hashable, Identifiable {
@@ -29,7 +31,8 @@ class InboxRowViewModel: Hashable, Identifiable {
     var messageText: String = ""
     var error: Error?
     var shouldScrollToBottom: Bool = false
-    
+    private let viewContext: NSManagedObjectContext = PersistenceController.shared.container.viewContext
+
     init(chat: Chat) {
         self.id = chat.id ?? UUID().uuidString
         self.chat = chat
@@ -76,18 +79,66 @@ class InboxRowViewModel: Hashable, Identifiable {
     func fetchMessages() async {
         if !messagesFetched {
             messagesFetched = true
-            print("Fetching Messages")
-            messages.removeAll()
             guard let chatId = chat.id else { return }
-            ChatsManager.shared.createMessagesListener(uid: chatId) { [weak self] messages in
-                self?.messages = messages
-                self?.shouldScrollToBottom = true
+
+            // Load cached messages for instant display
+            messages = loadMessagesFromCache(chatId: chatId)
+            if !messages.isEmpty {
+                shouldScrollToBottom = true
+            }
+
+            // Start listener for new messages only
+            let latestDate = messages.last?.date
+            ChatsManager.shared.createMessagesListener(uid: chatId, sinceDate: latestDate) { [weak self] newMessages in
+                guard let self else { return }
+                self.saveMessagesToCache(newMessages, chatId: chatId)
+                self.messages.append(contentsOf: newMessages)
+                self.shouldScrollToBottom = true
             }
         }
     }
-    
+
     func stopListeners() {
-        print("Stop Listening!!!")
+        ChatsManager.shared.stopMessagesListener()
+    }
+
+    // MARK: - Core Data Helpers
+
+    private func loadMessagesFromCache(chatId: String) -> [Message] {
+        let request = NSFetchRequest<CachedMessage>(entityName: "CachedMessage")
+        request.predicate = NSPredicate(format: "chatId == %@", chatId)
+        request.sortDescriptors = [NSSortDescriptor(key: "date", ascending: true)]
+        do {
+            let cached = try viewContext.fetch(request)
+            return cached.compactMap { Message.from($0) }
+        }
+        catch {
+            Logger.general.error("Error loading messages from cache: \(error.localizedDescription)")
+            return []
+        }
+    }
+
+    private func saveMessagesToCache(_ messages: [Message], chatId: String) {
+        for message in messages {
+            let request = NSFetchRequest<CachedMessage>(entityName: "CachedMessage")
+            request.predicate = NSPredicate(format: "id == %@", message.id ?? "")
+            request.fetchLimit = 1
+            do {
+                let existing = try viewContext.fetch(request).first
+                let entity = existing ?? CachedMessage(context: viewContext)
+                message.populate(entity)
+                entity.chatId = chatId
+            }
+            catch {
+                Logger.general.error("Error upserting message to cache: \(error.localizedDescription)")
+            }
+        }
+        do {
+            try viewContext.save()
+        }
+        catch {
+            Logger.general.error("Error saving message cache: \(error.localizedDescription)")
+        }
     }
     
     func sendMessage() {

--- a/Nightflyy/Screens/Profile/Views/ProfileView.swift
+++ b/Nightflyy/Screens/Profile/Views/ProfileView.swift
@@ -114,37 +114,38 @@ struct ProfileView: View {
                     Button {
                         viewModel.selectPresentView(for: .paywall)
                     } label: {
-                        HStack(spacing: 16) {
-                            Image("plus_button")
+                        HStack {
+                            Image("plus_badge")
                                 .resizable()
-                                .frame(width: 44, height: 44)
+                                .frame(width: 30, height: 30)
                             
-                            VStack(alignment: .leading, spacing: 4) {
+                            VStack(alignment: .leading) {
                                 Text("Nightflyy+ Perk")
-                                    .foregroundStyle(.gray)
-                                    .font(.system(size: 11))
+                                    .font(.system(size: 12))
+                                    .foregroundColor(.onlineBlue)
                                 
                                 Text(viewModel.account.perkName ?? "")
-                                    .font(.system(size: 14))
-                                    .fontWeight(.medium)
+                                    .font(.system(size: 15, weight: .bold))
+                                    .foregroundStyle(.white)
                                 
-                                if let details = viewModel.account.perkDetails {
-                                    Text(details)
-                                        .font(.system(size: 11))
-                                }
+                                Text(viewModel.account.perkDetails ?? "")
+                                    .font(.system(size: 10))
+                                    .foregroundStyle(.white)
                             }
                             
                             Spacer()
                             
                             Image(systemName: "chevron.right")
-                                .foregroundStyle(.gray)
+                                .foregroundStyle(.onlineBlue)
                         }
+                        .padding(8)
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(.onlineBlue, lineWidth: 1)
+                        }
+                        .padding(12)
                     }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
-                    
-                    Divider()
-                        .background(.white)
+
                 }
                 
                 if viewModel.canInteract {


### PR DESCRIPTION
## Summary
- **Core Data caching for app notifications**: Notifications are cached locally and only new records are fetched from Firebase using a date filter, providing instant UI on launch
- **Core Data caching for chat messages**: Messages are cached per chat in Core Data. Opening a chat loads cached messages instantly while a Firestore listener fetches only new messages. The listener is properly stopped when leaving the chat view
- Add `lastNotificationsFetchDate` to UserDefaults for tracking notification fetch dates
- Version bump to 3.2.2

## Test plan
- [ ] Cold launch with empty Core Data — notifications and messages should fetch all from Firebase and populate cache
- [ ] Kill and relaunch — notifications should appear instantly from cache before Firebase fetch
- [ ] Pull to refresh notifications — should only fetch new records and merge with cached data
- [ ] Delete a notification — should be removed from both Firebase and Core Data
- [ ] Open a chat — cached messages display instantly, listener fetches only new ones
- [ ] Send a message — appears in UI and gets cached via the listener
- [ ] Navigate away from chat — listener is stopped (no unnecessary Firestore reads)
- [ ] Reopen the same chat — messages load from cache, only delta fetched

🤖 Generated with [Claude Code](https://claude.com/claude-code)